### PR TITLE
Add binpkg feature to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN echo 'FEATURES="collision-protect parallel-fetch strict"' >> /etc/portage/ma
 
 RUN mkdir /etc/portage/env
 RUN echo 'FEATURES="test"' >> /etc/portage/env/test
+RUN echo 'FEATURES="binpkg"' >> /etc/portage/env/binpkg
 
 RUN touch /etc/portage/package.env
 RUN touch /etc/portage/package.use


### PR DESCRIPTION
To enable building binpkgs of the ebuild being tested, we need a change similar to this.
