### PR TITLE
Fix issue with newer docker-py entrypoint handling

### DIFF
--- a/etest/tests.py
+++ b/etest/tests.py
@@ -95,7 +95,7 @@ class Test(object):
                     '/overlay',
                     '/usr/portage',
                 ],
-                entrypoint = command[0],
+                entrypoint = ( command[0], ),
                 command = command[1:],
             )
 


### PR DESCRIPTION
```
>>> cont = c.create_container(image = 'busybox', entrypoint = 'sh', command = [ '-c', 'ls' ])
>>> c.start(cont)
Traceback (most recent call last):
  File "/usr/lib64/python3.3/site-packages/docker/client.py", line 120, in _raise_for_status
    response.raise_for_status()
  File "/usr/lib64/python3.3/site-packages/requests/models.py", line 834, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.3/site-packages/docker/utils/decorators.py", line 15, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "/usr/lib64/python3.3/site-packages/docker/client.py", line 1063, in start
    self._raise_for_status(res)
  File "/usr/lib64/python3.3/site-packages/docker/client.py", line 122, in _raise_for_status
    raise errors.APIError(e, response, explanation=explanation)
docker.errors.APIError: 404 Client Error: Not Found ("b'Cannot start container b6421c5401bcde07d1a165ec57b5eafbcc749fba9b62518cc455db394da85932: [8] System error: exec: "\\"sh\\"": executable file not found in $PATH'")
>>> cont = c.create_container(image = 'busybox', entrypoint = ['sh'], command = [ '-c', 'ls' ])
>>> c.start(cont)
>>> 
```